### PR TITLE
✨ [#70] 어드민 관리자 조직원 관리 페이징 기능 추가 및 초대 필드 추가

### DIFF
--- a/auth/src/main/java/be/auth/controller/AdminInviteController.java
+++ b/auth/src/main/java/be/auth/controller/AdminInviteController.java
@@ -30,7 +30,7 @@ public class AdminInviteController {
 
 	@Operation(
 		summary = "조직원 초대",
-		description = "관리자가 조직원 이메일을 등록하면 초대 메일을 발송합니다."
+		description = "관리자가 조직원의 이름, 이메일, 부서, 직급, 권한을 등록하면 초대 메일을 발송합니다."
 	)
 	@ApiErrorCodeExamples({
 		ErrorCode.EXIST_USER,

--- a/auth/src/main/java/be/auth/controller/AdminUserController.java
+++ b/auth/src/main/java/be/auth/controller/AdminUserController.java
@@ -1,0 +1,106 @@
+package be.auth.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import be.auth.dto.request.UpdateOrganizationUserRequest;
+import be.auth.dto.response.AdminOrganizationUserPageResponse;
+import be.auth.service.AdminUserQueryService;
+import be.auth.service.AdminUserService;
+import be.common.api.ApiResult;
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+import be.common.docs.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Admin의 조직원 관리", description = "조직원 수정 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/users")
+public class AdminUserController {
+
+	private final AdminUserService adminUserService;
+	private final AdminUserQueryService adminUserQueryService;
+
+	@Operation(
+		summary = "조직원 목록 조회",
+		description = "관리자가 삭제되지 않은 조직원 목록을 페이지 단위로 조회합니다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.ACCESS_DENIED
+	})
+	@GetMapping
+	public ApiResult<AdminOrganizationUserPageResponse> getOrganizationUsers(
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Role") String role,
+		@RequestParam(defaultValue = "0") int page
+	) {
+		if (!"ADMIN".equals(role)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		return ApiResult.ok(adminUserQueryService.getOrganizationUsers(page));
+	}
+
+	@Operation(
+		summary = "조직원 정보 수정",
+		description = "관리자가 조직원의 이름, 이메일, 부서, 직급, 권한을 수정합니다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.NOT_FOUND_USER,
+		ErrorCode.EXIST_USER,
+		ErrorCode.ACCESS_DENIED
+	})
+	@PutMapping("/{userId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> updateOrganizationUser(
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Role") String role,
+		@PathVariable UUID userId,
+		@RequestBody @Valid UpdateOrganizationUserRequest request
+	) {
+		if (!"ADMIN".equals(role)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		adminUserService.updateOrganizationUser(userId, request);
+		return ApiResult.ok();
+	}
+
+	@Operation(
+		summary = "조직원 삭제",
+		description = "관리자가 조직원을 삭제 처리합니다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.NOT_FOUND_USER,
+		ErrorCode.ACCESS_DENIED
+	})
+	@PutMapping("/{userId}/delete")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> deleteOrganizationUser(
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Role") String role,
+		@PathVariable UUID userId
+	) {
+		if (!"ADMIN".equals(role)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		adminUserService.deleteOrganizationUser(userId);
+		return ApiResult.ok();
+	}
+}

--- a/auth/src/main/java/be/auth/domain/User.java
+++ b/auth/src/main/java/be/auth/domain/User.java
@@ -49,6 +49,12 @@ public class User {
 	@Column
 	private String nickname;
 
+	@Column
+	private String department;
+
+	@Column
+	private String position;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(
 		name = "profile_image_id",
@@ -90,11 +96,15 @@ public class User {
 	@Column(nullable = false)
 	private boolean agreedMarketing;
 
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
 
 	private User(
 		UUID id,
 		String email,
 		String nickname,
+		String department,
+		String position,
 		ProfileImage profileImage,
 		OauthProvider provider,
 		String providerUserId,
@@ -109,6 +119,8 @@ public class User {
 		this.id = id;
 		this.email = email;
 		this.nickname = nickname;
+		this.department = department;
+		this.position = position;
 		this.profileImage = profileImage;
 		this.provider = provider;
 		this.providerUserId = providerUserId;
@@ -123,13 +135,18 @@ public class User {
 
 	public static User invitedUserByAdmin(
 		UUID id,
+		String name,
 		String email,
+		String department,
+		String position,
 		Role role
 	) {
 		return new User(
 			id,
 			email,
-			null,
+			name,
+			department,
+			position,
 			null,
 			null,
 			null,
@@ -158,7 +175,18 @@ public class User {
 	}
 
 	@PrePersist
+	private void onCreate() {
+		if (this.createdAt == null) {
+			this.createdAt = LocalDateTime.now();
+		}
+		validateState();
+	}
+
 	@PreUpdate
+	private void onUpdate() {
+		validateState();
+	}
+
 	private void validateState() {
 		if (this.providerUserId != null &&
 			(this.nickname == null || this.nickname.isBlank())) {
@@ -178,6 +206,8 @@ public class User {
 			id,
 			email,
 			email,  // 서버 가입 유저는 이메일을 닉네임으로 사용
+			null,
+			null,
 			null,
 			OauthProvider.SERVER,
 			email,
@@ -211,6 +241,23 @@ public class User {
 	public void changeNickname(String nickname) {
 		Preconditions.validate(nickname != null && !nickname.isBlank(), ErrorCode.INVALID_NICKNAME);
 		this.nickname = nickname;
+	}
+
+	public void updateOrganizationInfo(
+		String name,
+		String email,
+		String department,
+		String position,
+		Role role
+	) {
+		Preconditions.validate(name != null && !name.isBlank(), ErrorCode.INVALID_NICKNAME);
+		Preconditions.validate(email != null && !email.isBlank(), ErrorCode.INVALID_EMAIL);
+
+		this.nickname = name;
+		this.email = email;
+		this.department = department;
+		this.position = position;
+		this.role = role;
 	}
 
 	public void changeImage(ProfileImage image) {

--- a/auth/src/main/java/be/auth/dto/request/InviteUserRequest.java
+++ b/auth/src/main/java/be/auth/dto/request/InviteUserRequest.java
@@ -1,9 +1,19 @@
 package be.auth.dto.request;
 
 import be.auth.jwt.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record InviteUserRequest(
+	@NotBlank
+	String name,
+	@NotBlank
 	String email,
+	@NotBlank
+	String department,
+	@NotBlank
+	String position,
+	@NotNull
 	Role role
 )
 {}

--- a/auth/src/main/java/be/auth/dto/request/UpdateOrganizationUserRequest.java
+++ b/auth/src/main/java/be/auth/dto/request/UpdateOrganizationUserRequest.java
@@ -1,0 +1,19 @@
+package be.auth.dto.request;
+
+import be.auth.jwt.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateOrganizationUserRequest(
+	@NotBlank
+	String name,
+	@NotBlank
+	String email,
+	@NotBlank
+	String department,
+	@NotBlank
+	String position,
+	@NotNull
+	Role role
+) {
+}

--- a/auth/src/main/java/be/auth/dto/response/AdminOrganizationUserItemResponse.java
+++ b/auth/src/main/java/be/auth/dto/response/AdminOrganizationUserItemResponse.java
@@ -1,0 +1,18 @@
+package be.auth.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import be.auth.jwt.Role;
+
+public record AdminOrganizationUserItemResponse(
+	UUID userId,
+	String name,
+	String email,
+	String department,
+	String position,
+	Role role,
+	boolean isActive,
+	LocalDateTime createdAt
+) {
+}

--- a/auth/src/main/java/be/auth/dto/response/AdminOrganizationUserPageResponse.java
+++ b/auth/src/main/java/be/auth/dto/response/AdminOrganizationUserPageResponse.java
@@ -1,0 +1,13 @@
+package be.auth.dto.response;
+
+import java.util.List;
+
+public record AdminOrganizationUserPageResponse(
+	List<AdminOrganizationUserItemResponse> items,
+	int page,
+	int size,
+	long totalElements,
+	int totalPages,
+	boolean hasNext
+) {
+}

--- a/auth/src/main/java/be/auth/repository/UserRepository.java
+++ b/auth/src/main/java/be/auth/repository/UserRepository.java
@@ -3,8 +3,12 @@ package be.auth.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import be.auth.dto.response.AdminOrganizationUserItemResponse;
 import be.auth.domain.OauthProvider;
 import be.auth.domain.User;
 import be.common.api.CustomException;
@@ -25,4 +29,28 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 	boolean existsByEmail(String email);
 
 	boolean existsByNickname(String nickname);
+
+	@Query(
+		value = """
+			select new be.auth.dto.response.AdminOrganizationUserItemResponse(
+				u.id,
+				u.nickname,
+				u.email,
+				u.department,
+				u.position,
+				u.role,
+				u.isActive,
+				u.createdAt
+			)
+			from User u
+			where u.isDeleted = false
+			order by u.createdAt desc, u.id desc
+		""",
+		countQuery = """
+			select count(u)
+			from User u
+			where u.isDeleted = false
+		"""
+	)
+	Page<AdminOrganizationUserItemResponse> findOrganizationUserPage(Pageable pageable);
 }

--- a/auth/src/main/java/be/auth/service/AdminInviteService.java
+++ b/auth/src/main/java/be/auth/service/AdminInviteService.java
@@ -31,7 +31,10 @@ public class AdminInviteService {
 
 		User user = User.invitedUserByAdmin(
 			UUID.randomUUID(),
+			request.name(),
 			request.email(),
+			request.department(),
+			request.position(),
 			request.role()
 		);
 
@@ -41,6 +44,4 @@ public class AdminInviteService {
 			new UserInvitedEvent(user.getId(), user.getEmail())
 		);
 	}
-
-
 }

--- a/auth/src/main/java/be/auth/service/AdminUserQueryService.java
+++ b/auth/src/main/java/be/auth/service/AdminUserQueryService.java
@@ -1,0 +1,39 @@
+package be.auth.service;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import be.auth.dto.response.AdminOrganizationUserPageResponse;
+import be.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserQueryService {
+
+	private static final int PAGE_SIZE = 9;
+
+	private final UserRepository userRepository;
+
+	public AdminOrganizationUserPageResponse getOrganizationUsers(int page) {
+		var result = userRepository.findOrganizationUserPage(
+			PageRequest.of(
+				page,
+				PAGE_SIZE,
+				Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id"))
+			)
+		);
+
+		return new AdminOrganizationUserPageResponse(
+			result.getContent(),
+			result.getNumber(),
+			result.getSize(),
+			result.getTotalElements(),
+			result.getTotalPages(),
+			result.hasNext()
+		);
+	}
+}

--- a/auth/src/main/java/be/auth/service/AdminUserService.java
+++ b/auth/src/main/java/be/auth/service/AdminUserService.java
@@ -1,0 +1,45 @@
+package be.auth.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import be.auth.dto.request.UpdateOrganizationUserRequest;
+import be.auth.repository.UserRepository;
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminUserService {
+
+	private final UserRepository userRepository;
+
+	public void updateOrganizationUser(
+		UUID userId,
+		UpdateOrganizationUserRequest request
+	) {
+		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+
+		if (!user.getEmail().equals(request.email())
+			&& userRepository.existsByEmail(request.email())) {
+			throw new CustomException(ErrorCode.EXIST_USER);
+		}
+
+		user.updateOrganizationInfo(
+			request.name(),
+			request.email(),
+			request.department(),
+			request.position(),
+			request.role()
+		);
+	}
+
+	public void deleteOrganizationUser(UUID userId) {
+		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+		user.delete();
+	}
+}

--- a/auth/src/test/java/be/auth/AuthApplicationTests.java
+++ b/auth/src/test/java/be/auth/AuthApplicationTests.java
@@ -1,10 +1,21 @@
 package be.auth;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AuthApplicationTests {
+
+	@MockitoBean
+	private RedisConnectionFactory redisConnectionFactory;
+
+	@MockitoBean
+	private StringRedisTemplate stringRedisTemplate;
 
 	@Test
 	void contextLoads() {

--- a/auth/src/test/java/be/auth/config/TestRedisConfig.java
+++ b/auth/src/test/java/be/auth/config/TestRedisConfig.java
@@ -1,0 +1,24 @@
+package be.auth.config;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@Profile("test")
+public class TestRedisConfig {
+
+	@Bean
+	RedisConnectionFactory redisConnectionFactory() {
+		return mock(RedisConnectionFactory.class);
+	}
+
+	@Bean
+	StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		return mock(StringRedisTemplate.class);
+	}
+}

--- a/auth/src/test/java/be/auth/controller/UserConsentControllerApiTest.java
+++ b/auth/src/test/java/be/auth/controller/UserConsentControllerApiTest.java
@@ -45,7 +45,9 @@ class UserConsentControllerApiTest {
 		UUID userId = UUID.randomUUID();
 		String body = """
 			{
-			  "agreedPrivacy": true
+			  "agreedTermsOfService": true,
+			  "agreedPrivacyPolicy": true,
+			  "agreedMarketing": false
 			}
 			""";
 
@@ -59,7 +61,10 @@ class UserConsentControllerApiTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
 
-		verify(userConsentService).completeFirstLogin(userId, new be.auth.dto.request.ConsentRequest(true));
+		verify(userConsentService).completeFirstLogin(
+			userId,
+			new be.auth.dto.request.ConsentRequest(true, true, false)
+		);
 		verify(authNotificationPreferenceService).initializeAndPublish(userId);
 	}
 }

--- a/auth/src/test/java/be/auth/service/AdminInviteServiceTest.java
+++ b/auth/src/test/java/be/auth/service/AdminInviteServiceTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 
+import be.auth.domain.User;
 import be.auth.dto.request.InviteUserRequest;
 import be.auth.event.UserInvitedEvent;
 import be.auth.jwt.Role;
@@ -31,13 +33,24 @@ class AdminInviteServiceTest {
 		//given
 		String email = "test@test.com";
 		when(userRepository.existsByEmail(email)).thenReturn(false);
-		InviteUserRequest request = new InviteUserRequest(email, Role.USER);
+		InviteUserRequest request = new InviteUserRequest(
+			"테스트유저",
+			email,
+			"개발팀",
+			"사원",
+			Role.USER
+		);
 
 		//when
 		adminInviteService.inviteUser(request);
 
 		//then
-		verify(userRepository, times(1)).save(any());
+		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+		verify(userRepository, times(1)).save(userCaptor.capture());
+		assertThat(userCaptor.getValue().getEmail()).isEqualTo(email);
+		assertThat(userCaptor.getValue().getNickname()).isEqualTo("테스트유저");
+		assertThat(userCaptor.getValue().getDepartment()).isEqualTo("개발팀");
+		assertThat(userCaptor.getValue().getPosition()).isEqualTo("사원");
 		verify(eventPublisher, times(1)).publishEvent(any(UserInvitedEvent.class));
 	}
 
@@ -48,7 +61,13 @@ class AdminInviteServiceTest {
 		//given
 		String email = "test@test.com";
 		when(userRepository.existsByEmail(email)).thenReturn(true);
-		InviteUserRequest request = new InviteUserRequest(email, Role.USER);
+		InviteUserRequest request = new InviteUserRequest(
+			"테스트유저",
+			email,
+			"개발팀",
+			"사원",
+			Role.USER
+		);
 
 		//when & then
 		assertThatThrownBy(() -> adminInviteService.inviteUser(request))

--- a/auth/src/test/java/be/auth/service/AdminUserQueryServiceTest.java
+++ b/auth/src/test/java/be/auth/service/AdminUserQueryServiceTest.java
@@ -1,0 +1,71 @@
+package be.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import be.auth.dto.response.AdminOrganizationUserItemResponse;
+import be.auth.jwt.Role;
+import be.auth.repository.UserRepository;
+
+class AdminUserQueryServiceTest {
+
+	private final UserRepository userRepository = mock(UserRepository.class);
+
+	private final AdminUserQueryService adminUserQueryService =
+		new AdminUserQueryService(userRepository);
+
+	@Test
+	@DisplayName("조직원 목록 조회는 페이지 크기 9로 고정된다")
+	void 조직원_목록_조회_성공() {
+		AdminOrganizationUserItemResponse item =
+			new AdminOrganizationUserItemResponse(
+				UUID.randomUUID(),
+				"홍길동",
+				"hong@test.com",
+				"개발팀",
+				"대리",
+				Role.USER,
+				true,
+				LocalDateTime.of(2026, 3, 31, 9, 0)
+			);
+		PageImpl<AdminOrganizationUserItemResponse> page = new PageImpl<>(
+			List.of(item),
+			PageRequest.of(1, 9),
+			10
+		);
+
+		when(userRepository.findOrganizationUserPage(org.mockito.ArgumentMatchers.any(Pageable.class)))
+			.thenReturn(page);
+
+		var response = adminUserQueryService.getOrganizationUsers(1);
+
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(userRepository).findOrganizationUserPage(pageableCaptor.capture());
+		assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(1);
+		assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(9);
+		assertThat(pageableCaptor.getValue().getSort().getOrderFor("createdAt")).isNotNull();
+		assertThat(pageableCaptor.getValue().getSort().getOrderFor("createdAt").isDescending()).isTrue();
+
+		assertThat(response.items()).hasSize(1);
+		assertThat(response.page()).isEqualTo(1);
+		assertThat(response.size()).isEqualTo(9);
+		assertThat(response.totalElements()).isEqualTo(10);
+		assertThat(response.totalPages()).isEqualTo(2);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.items().get(0).userId()).isNotNull();
+		assertThat(response.items().get(0).name()).isEqualTo("홍길동");
+	}
+}

--- a/auth/src/test/java/be/auth/service/AdminUserServiceTest.java
+++ b/auth/src/test/java/be/auth/service/AdminUserServiceTest.java
@@ -1,0 +1,134 @@
+package be.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import be.auth.domain.User;
+import be.auth.dto.request.UpdateOrganizationUserRequest;
+import be.auth.jwt.Role;
+import be.auth.repository.UserRepository;
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+
+class AdminUserServiceTest {
+
+	private final UserRepository userRepository = mock(UserRepository.class);
+
+	private final AdminUserService adminUserService =
+		new AdminUserService(userRepository);
+
+	@Test
+	@DisplayName("관리자가 조직원 정보를 수정할 수 있다")
+	void 조직원_정보_수정_성공() {
+		UUID userId = UUID.randomUUID();
+		User user = User.invitedUserByAdmin(
+			userId,
+			"기존이름",
+			"before@test.com",
+			"디자인팀",
+			"사원",
+			Role.USER
+		);
+		UpdateOrganizationUserRequest request = new UpdateOrganizationUserRequest(
+			"새이름",
+			"after@test.com",
+			"개발팀",
+			"대리",
+			Role.ADMIN
+		);
+
+		when(userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER))
+			.thenReturn(user);
+		when(userRepository.existsByEmail(request.email())).thenReturn(false);
+
+		adminUserService.updateOrganizationUser(userId, request);
+
+		verify(userRepository).findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+		assertThat(user.getNickname()).isEqualTo("새이름");
+		assertThat(user.getEmail()).isEqualTo("after@test.com");
+		assertThat(user.getDepartment()).isEqualTo("개발팀");
+		assertThat(user.getPosition()).isEqualTo("대리");
+		assertThat(user.getRole()).isEqualTo(Role.ADMIN);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 조직원 수정 시 예외가 발생한다")
+	void 존재하지_않는_조직원_수정_실패() {
+		UUID userId = UUID.randomUUID();
+		UpdateOrganizationUserRequest request = new UpdateOrganizationUserRequest(
+			"새이름",
+			"after@test.com",
+			"개발팀",
+			"대리",
+			Role.USER
+		);
+
+		when(userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER))
+			.thenThrow(new CustomException(ErrorCode.NOT_FOUND_USER));
+
+		assertThatThrownBy(() -> adminUserService.updateOrganizationUser(userId, request))
+			.isInstanceOf(CustomException.class)
+			.extracting(e -> ((CustomException) e).getErrorCode())
+			.isEqualTo(ErrorCode.NOT_FOUND_USER);
+	}
+
+	@Test
+	@DisplayName("다른 사용자가 이미 쓰는 이메일로 수정하면 예외가 발생한다")
+	void 이메일_중복_수정_실패() {
+		UUID userId = UUID.randomUUID();
+		User user = User.invitedUserByAdmin(
+			userId,
+			"기존이름",
+			"before@test.com",
+			"디자인팀",
+			"사원",
+			Role.USER
+		);
+		UpdateOrganizationUserRequest request = new UpdateOrganizationUserRequest(
+			"새이름",
+			"duplicate@test.com",
+			"개발팀",
+			"대리",
+			Role.USER
+		);
+
+		when(userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER))
+			.thenReturn(user);
+		when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+		assertThatThrownBy(() -> adminUserService.updateOrganizationUser(userId, request))
+			.isInstanceOf(CustomException.class)
+			.extracting(e -> ((CustomException) e).getErrorCode())
+			.isEqualTo(ErrorCode.EXIST_USER);
+	}
+
+	@Test
+	@DisplayName("관리자가 조직원을 삭제 처리하면 isDeleted만 true로 변경된다")
+	void 조직원_삭제_성공() {
+		UUID userId = UUID.randomUUID();
+		User user = User.invitedUserByAdmin(
+			userId,
+			"기존이름",
+			"before@test.com",
+			"디자인팀",
+			"사원",
+			Role.USER
+		);
+
+		when(userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER))
+			.thenReturn(user);
+
+		adminUserService.deleteOrganizationUser(userId);
+
+		assertThat(user.isDeleted()).isTrue();
+		assertThat(user.isActive()).isFalse();
+	}
+}

--- a/auth/src/test/java/be/auth/service/InviteUserIntegrationTest.java
+++ b/auth/src/test/java/be/auth/service/InviteUserIntegrationTest.java
@@ -1,21 +1,33 @@
 package be.auth.service;
 
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import be.auth.dto.request.InviteUserRequest;
 import be.auth.jwt.Role;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class InviteUserIntegrationTest {
+	@MockitoBean
+	private RedisConnectionFactory redisConnectionFactory;
+
+	@MockitoBean
+	private StringRedisTemplate stringRedisTemplate;
+
 	@Autowired
 	private AdminInviteService adminInviteService;
 
@@ -31,13 +43,23 @@ class InviteUserIntegrationTest {
 
 		//given
 		String email = UUID.randomUUID() + "@test.com";
-		InviteUserRequest request = new InviteUserRequest(email, Role.USER);
+		InviteUserRequest request = new InviteUserRequest(
+			"신규 조직원",
+			email,
+			"개발팀",
+			"사원",
+			Role.USER
+		);
 
 		//when
 		adminInviteService.inviteUser(request);
 
 		//then
-		verify(invitedEmailService, times(1))
-			.sendInviteEmail(email);
+		await()
+			.atMost(Duration.ofSeconds(3))
+			.untilAsserted(() ->
+				verify(invitedEmailService, times(1))
+					.sendInviteEmail(email)
+			);
 	}
 }

--- a/auth/src/test/java/be/auth/service/ProfileImageServiceTest.java
+++ b/auth/src/test/java/be/auth/service/ProfileImageServiceTest.java
@@ -13,7 +13,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -25,6 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @Transactional
 class ProfileImageServiceTest {
+	@MockitoBean
+	private RedisConnectionFactory redisConnectionFactory;
+
+	@MockitoBean
+	private StringRedisTemplate stringRedisTemplate;
+
 	@Autowired
 	private ProfileImageService profileImageService;
 

--- a/auth/src/test/java/be/auth/service/UserConsentServiceTest.java
+++ b/auth/src/test/java/be/auth/service/UserConsentServiceTest.java
@@ -34,13 +34,13 @@ class UserConsentServiceTest {
 			.thenReturn(Optional.of(user));
 		when(user.isFirstLogin()).thenReturn(true);
 
-		ConsentRequest request = new ConsentRequest(true);
+		ConsentRequest request = new ConsentRequest(true, true, false);
 
 		//when
 		userConsentService.completeFirstLogin(userId, request);
 
 		//then
-		verify(user).completeFirstLogin();
+		verify(user).completeFirstLogin(true, true, false);
 	}
 
 	@Test
@@ -55,7 +55,7 @@ class UserConsentServiceTest {
 			.thenReturn(Optional.of(user));
 		when(user.isFirstLogin()).thenReturn(false);
 
-		ConsentRequest request = new ConsentRequest(true);
+		ConsentRequest request = new ConsentRequest(true, true, false);
 
 		//when & then
 		assertThatThrownBy(() ->
@@ -75,7 +75,7 @@ class UserConsentServiceTest {
 			.thenReturn(Optional.of(user));
 		when(user.isFirstLogin()).thenReturn(true);
 
-		ConsentRequest request = new ConsentRequest(false);
+		ConsentRequest request = new ConsentRequest(false, true, false);
 
 		//when & then
 		assertThatThrownBy(() ->

--- a/auth/src/test/resources/application-test.yml
+++ b/auth/src/test/resources/application-test.yml
@@ -1,4 +1,10 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration
+
   datasource:
     url: jdbc:h2:mem:notification-test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
@@ -11,7 +17,26 @@ spring:
     show-sql: false
     open-in-view: false
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      ssl:
+        enabled: false
+
   kafka:
     listener:
       auto-startup: false
     bootstrap-servers: dummy:9092
+
+app:
+  invite:
+    login-url: http://localhost/test-login
+  email:
+    from: test@example.com
+
+oauth:
+  google:
+    client-id: test-google-client-id
+    client-secret: test-google-client-secret
+    redirect-uri: http://localhost/test/oauth/google/callback


### PR DESCRIPTION
## 연관된 이슈
closed #70 


## 1️⃣ 작업 내용

> 어드민 관리자가 조직원 관리 페이지를 페이징하여 볼 수 있도록 기능 추가


## 2️⃣ 스크린샷 (선택)

<img width="568" height="392" alt="image" src="https://github.com/user-attachments/assets/43b63e50-a9b0-4ecc-ad7a-9351c301d4c5" />
<img width="216" height="245" alt="image" src="https://github.com/user-attachments/assets/546db860-1222-4519-94a0-9b280b209f8c" />


## 3️⃣ 리뷰 요구사항 (선택)

> 유저 엔티티 변경점 확인 부탁드립니다!
> 유저 초대 확인 부탁드립니다!