### PR TITLE
:bug: [#73] 헤더 삭제 후 주입으로 변경

### DIFF
--- a/gateway/src/main/java/be/gateway/jwt/JwtAuthenticationFilter.java
+++ b/gateway/src/main/java/be/gateway/jwt/JwtAuthenticationFilter.java
@@ -95,8 +95,13 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 					.request(
 						exchange.getRequest()
 							.mutate()
-							.header("X-User-Id", userId)
-							.header("X-User-Role", role)
+							.headers(headers -> {
+								headers.remove("X-User-Id");
+								headers.remove("X-User-Role");
+
+								headers.set("X-User-Id", userId);
+								headers.set("X-User-Role", role);
+							})
 							.build()
 					)
 					.build()


### PR DESCRIPTION
## 연관된 이슈

> 관련된 이슈 번호를 적어주세요. (예: #이슈번호)
closed #73 

> 헤더를 삭제 후 주입하지 않아 헤더를 넣어 보내면 공격받을 수 있는 문제.

## 1️⃣ 어떤 상황에서 발생한 버그인가요?
1. 공격자가 token을 정당하게 발급받는다.
2. 공격자가 header에 userId를 주입한다.
3. 서버는 헤더에 이미 값이 있기 때문에 덮어쓰지 않는다.

## 2️⃣ 예상 결과
토큰에서 추출한 아이디값만을 헤더에 삽입

## 3️⃣ 실제 결과
이미 존재한다면 덮어쓰지 않음