### PR TITLE
✨ [#75] neo4j 데이터 시각화 API 구현 

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -72,6 +72,18 @@ spring:
               predicates:
                 - Path=/greenroom/ai, /greenroom/ai/**
 
+            - id: greenroom-graph-internal
+              uri: http://${GREENROOM_SERVER_HOST:localhost}:${GREENROOM_SERVER_PORT:8082}
+              predicates:
+                - Path=/api/v1/graph_nodes, /api/v1/graph_analyses
+
+            - id: greenroom-graph-jwt
+              uri: http://${GREENROOM_SERVER_HOST:localhost}:${GREENROOM_SERVER_PORT:8082}
+              predicates:
+                - Path=/api/v1/graph/users/**, /api/v1/graph/organization/data
+              filters:
+                - JwtAuthenticationFilter
+
             - id: greenroom
               uri: http://${GREENROOM_SERVER_HOST:localhost}:${GREENROOM_SERVER_PORT:8082}
               predicates:

--- a/greenroom/src/main/java/be/common/api/ApiAdvice.java
+++ b/greenroom/src/main/java/be/common/api/ApiAdvice.java
@@ -2,7 +2,10 @@ package be.common.api;
 
 import java.util.Arrays;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -29,12 +32,40 @@ public class ApiAdvice {
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ErrorResponse.ErrorData> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+	public ResponseEntity<ErrorResponse.ErrorData> methodArgumentNotValidException(
+		MethodArgumentNotValidException e,
+		HttpServletRequest request
+	) {
 		e.printStackTrace();
 		var details = Arrays.toString(e.getDetailMessageArguments());
 		var message = details.split(",", 2)[1].replace("]", "").trim();
 
+		if (isGraphWriteEndpoint(request)) {
+			return ErrorResponse.error(ErrorCode.GRAPH_REQUEST_SCHEMA_MISMATCH);
+		}
+
 		return ErrorResponse.error(ErrorCode.VALIDATION_ERROR);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse.ErrorData> httpMessageNotReadableException(
+		HttpMessageNotReadableException e,
+		HttpServletRequest request
+	) {
+		e.printStackTrace();
+
+		if (isGraphWriteEndpoint(request)) {
+			return ErrorResponse.error(ErrorCode.GRAPH_REQUEST_SCHEMA_MISMATCH);
+		}
+
+		return ErrorResponse.error(ErrorCode.VALIDATION_ERROR);
+	}
+
+	private boolean isGraphWriteEndpoint(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		String method = request.getMethod();
+		return ("PUT".equals(method) && "/api/v1/graph_nodes".equals(uri))
+			|| ("POST".equals(method) && "/api/v1/graph_analyses".equals(uri));
 	}
 
 }

--- a/greenroom/src/main/java/be/common/api/ErrorCode.java
+++ b/greenroom/src/main/java/be/common/api/ErrorCode.java
@@ -22,6 +22,20 @@ public enum ErrorCode {
 	TRACKING_UNRESOLVED_ETC_REQUIRED(HttpStatus.BAD_REQUEST, "미해결 걸림돌 항목이 ETC면 unresolvedBlockerOther가 필요합니다."),
 	TRACKING_RESOLVED_ETC_FORBIDDEN(HttpStatus.BAD_REQUEST, "해결 도움 항목이 ETC가 아니면 resolvedHelpOther를 보낼 수 없습니다."),
 	TRACKING_UNRESOLVED_ETC_FORBIDDEN(HttpStatus.BAD_REQUEST, "미해결 걸림돌 항목이 ETC가 아니면 unresolvedBlockerOther를 보낼 수 없습니다."),
+	GRAPH_REQUEST_SCHEMA_MISMATCH(HttpStatus.BAD_REQUEST, "AI 서버가 보낸 그래프 요청 데이터 구조가 백엔드 스펙과 다릅니다."),
+	GRAPH_RESPONSE_SCHEMA_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "그래프 응답 데이터 구조가 백엔드 응답 스펙과 다릅니다."),
+	GRAPH_INVALID_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "graph_nodes type은 graph_cumulative 이어야 합니다."),
+	GRAPH_PAYLOAD_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 요청 data payload는 필수입니다."),
+	GRAPH_INVALID_GROUP(HttpStatus.BAD_REQUEST, "유효하지 않은 graph group 입니다."),
+	GRAPH_INVALID_TREND(HttpStatus.BAD_REQUEST, "유효하지 않은 graph trend 입니다."),
+	GRAPH_NODE_LABEL_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 노드 label은 필수입니다."),
+	GRAPH_EDGE_SOURCE_LABEL_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 엣지 source_label은 필수입니다."),
+	GRAPH_EDGE_TARGET_LABEL_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 엣지 target_label은 필수입니다."),
+	GRAPH_EDGE_RELATIONSHIP_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 엣지 relationship은 필수입니다."),
+	GRAPH_WEIGHT_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 weight 값은 필수입니다."),
+	GRAPH_MENTION_COUNT_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 mention_count 값은 필수입니다."),
+	GRAPH_ANALYSIS_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "그래프 분석 analysis_type은 필수입니다."),
+	GRAPH_ANALYSIS_PAYLOAD_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "그래프 분석 payload 직렬화에 실패했습니다."),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/greenroom/src/main/java/be/common/api/ErrorCode.java
+++ b/greenroom/src/main/java/be/common/api/ErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에러입니다. 백엔드팀에 문의하세요."),
 	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 	NOTIFICATION_EVENT_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 이벤트 직렬화에 실패했습니다."),
 	DOES_NOT_EXIST_TICKET(HttpStatus.BAD_REQUEST, "존재하지 않는 티켓 id입니다."),
 	NO_TICKET_ACCESS(HttpStatus.FORBIDDEN, "해당 티켓에 접근 권한이 없습니다."),

--- a/greenroom/src/main/java/be/greenroom/graph/controller/GraphController.java
+++ b/greenroom/src/main/java/be/greenroom/graph/controller/GraphController.java
@@ -9,12 +9,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import be.common.api.ApiResult;
+import be.common.api.CustomException;
 import be.common.api.ErrorCode;
 import be.common.docs.ApiErrorCodeExamples;
 import be.greenroom.graph.dto.request.CreateGraphAnalysisRequest;
@@ -24,8 +26,10 @@ import be.greenroom.graph.dto.response.GraphUserDataResponse;
 import be.greenroom.graph.service.GraphCommandService;
 import be.greenroom.graph.service.GraphQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
@@ -100,11 +104,19 @@ public class GraphController {
 	)
 	@ApiErrorCodeExamples({
 		ErrorCode.VALIDATION_ERROR,
+		ErrorCode.ACCESS_DENIED,
 		ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
 	})
 	@GetMapping("/graph/users/{userId}/data")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResult<GraphUserDataResponse> getUserGraphData(@PathVariable @NotNull UUID userId) {
+	public ApiResult<GraphUserDataResponse> getUserGraphData(
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Id") @NotBlank String userIdHeader,
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Role") @NotBlank String role,
+		@PathVariable @NotNull UUID userId
+	) {
+		validateAdminAccess(userIdHeader, role);
 		return ApiResult.ok(graphQueryService.getGraphVisualizationData(userId));
 	}
 
@@ -113,11 +125,26 @@ public class GraphController {
 		description = "활성 사용자 전체를 조직 구성원으로 간주하여 프론트엔드 시각화용 누적 그래프를 반환한다."
 	)
 	@ApiErrorCodeExamples({
+		ErrorCode.ACCESS_DENIED,
 		ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
 	})
 	@GetMapping("/graph/organization/data")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResult<GraphUserDataResponse> getOrganizationGraphData() {
+	public ApiResult<GraphUserDataResponse> getOrganizationGraphData(
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Id") @NotBlank String userIdHeader,
+		@Parameter(hidden = true)
+		@RequestHeader("X-User-Role") @NotBlank String role
+	) {
+		validateAdminAccess(userIdHeader, role);
 		return ApiResult.ok(graphQueryService.getOrganizationGraphVisualizationData());
+	}
+
+	private void validateAdminAccess(String userIdHeader, String role) {
+		UUID.fromString(userIdHeader);
+
+		if (!"ADMIN".equals(role)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
 	}
 }

--- a/greenroom/src/main/java/be/greenroom/graph/controller/GraphController.java
+++ b/greenroom/src/main/java/be/greenroom/graph/controller/GraphController.java
@@ -1,0 +1,123 @@
+package be.greenroom.graph.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import be.common.api.ApiResult;
+import be.common.api.ErrorCode;
+import be.common.docs.ApiErrorCodeExamples;
+import be.greenroom.graph.dto.request.CreateGraphAnalysisRequest;
+import be.greenroom.graph.dto.request.PutGraphNodesRequest;
+import be.greenroom.graph.dto.response.GraphNodesResponse;
+import be.greenroom.graph.dto.response.GraphUserDataResponse;
+import be.greenroom.graph.service.GraphCommandService;
+import be.greenroom.graph.service.GraphQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Graph", description = "그래프 누적 데이터 API")
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class GraphController {
+
+	private final GraphQueryService graphQueryService;
+	private final GraphCommandService graphCommandService;
+
+	@Operation(
+		summary = "기존 누적 그래프 조회(BE -> AI)",
+		description = "AI 서버의 EMA 계산용 기존 누적 데이터를 반환한다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.VALIDATION_ERROR,
+		ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+	})
+	@GetMapping("/graph_nodes")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<GraphNodesResponse> getGraphNodes(@RequestParam("user_id") @NotNull UUID userId) {
+		return ApiResult.ok(graphQueryService.getCumulativeGraph(userId));
+	}
+
+	@Operation(
+		summary = "누적 그래프 저장(AI -> BE)",
+		description = "AI 서버가 계산한 누적 그래프를 저장한다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.GRAPH_REQUEST_SCHEMA_MISMATCH,
+		ErrorCode.GRAPH_INVALID_REQUEST_TYPE,
+		ErrorCode.GRAPH_PAYLOAD_REQUIRED,
+		ErrorCode.GRAPH_INVALID_GROUP,
+		ErrorCode.GRAPH_INVALID_TREND,
+		ErrorCode.GRAPH_NODE_LABEL_REQUIRED,
+		ErrorCode.GRAPH_EDGE_SOURCE_LABEL_REQUIRED,
+		ErrorCode.GRAPH_EDGE_TARGET_LABEL_REQUIRED,
+		ErrorCode.GRAPH_EDGE_RELATIONSHIP_REQUIRED,
+		ErrorCode.GRAPH_WEIGHT_REQUIRED,
+		ErrorCode.GRAPH_MENTION_COUNT_REQUIRED
+	})
+	@PutMapping("/graph_nodes")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> upsertGraphNodes(@RequestBody @Valid PutGraphNodesRequest request) {
+		graphCommandService.upsertCumulativeGraph(request);
+		return ApiResult.ok();
+	}
+
+	@Operation(
+		summary = "그래프 분석 저장(AI -> BE)",
+		description = "에피소드 단위 그래프 분석 원본을 저장한다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.GRAPH_REQUEST_SCHEMA_MISMATCH,
+		ErrorCode.GRAPH_PAYLOAD_REQUIRED,
+		ErrorCode.GRAPH_ANALYSIS_TYPE_REQUIRED,
+		ErrorCode.GRAPH_ANALYSIS_PAYLOAD_SERIALIZATION_FAILED
+	})
+	@PostMapping("/graph_analyses")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResult<Void> createGraphAnalysis(@RequestBody @Valid CreateGraphAnalysisRequest request) {
+		graphCommandService.saveGraphAnalysis(request);
+		return ApiResult.ok();
+	}
+
+	@Operation(
+		summary = "사용자 그래프 조회(FE)",
+		description = "프론트엔드 시각화용 누적 그래프를 사용자 단위로 반환한다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.VALIDATION_ERROR,
+		ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+	})
+	@GetMapping("/graph/users/{userId}/data")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<GraphUserDataResponse> getUserGraphData(@PathVariable @NotNull UUID userId) {
+		return ApiResult.ok(graphQueryService.getGraphVisualizationData(userId));
+	}
+
+	@Operation(
+		summary = "조직 그래프 조회(FE)",
+		description = "활성 사용자 전체를 조직 구성원으로 간주하여 프론트엔드 시각화용 누적 그래프를 반환한다."
+	)
+	@ApiErrorCodeExamples({
+		ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+	})
+	@GetMapping("/graph/organization/data")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<GraphUserDataResponse> getOrganizationGraphData() {
+		return ApiResult.ok(graphQueryService.getOrganizationGraphVisualizationData());
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/domain/GraphAnalysis.java
+++ b/greenroom/src/main/java/be/greenroom/graph/domain/GraphAnalysis.java
@@ -1,0 +1,85 @@
+package be.greenroom.graph.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "graph_analyses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GraphAnalysis {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "episode_id", length = 100)
+	private String episodeId;
+
+	@Column(name = "session_id", length = 100)
+	private String sessionId;
+
+	@Column(name = "analysis_type", nullable = false, length = 50)
+	private String analysisType;
+
+	@Lob
+	@Column(nullable = false, columnDefinition = "LONGTEXT")
+	private String payload;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Builder
+	private GraphAnalysis(
+		UUID userId,
+		String episodeId,
+		String sessionId,
+		String analysisType,
+		String payload
+	) {
+		this.userId = userId;
+		this.episodeId = episodeId;
+		this.sessionId = sessionId;
+		this.analysisType = analysisType;
+		this.payload = payload;
+	}
+
+	public static GraphAnalysis create(
+		UUID userId,
+		String episodeId,
+		String sessionId,
+		String analysisType,
+		String payload
+	) {
+		return GraphAnalysis.builder()
+			.userId(userId)
+			.episodeId(episodeId)
+			.sessionId(sessionId)
+			.analysisType(analysisType)
+			.payload(payload)
+			.build();
+	}
+
+	@PrePersist
+	void prePersist() {
+		if (createdAt == null) {
+			createdAt = LocalDateTime.now();
+		}
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/domain/GraphGroup.java
+++ b/greenroom/src/main/java/be/greenroom/graph/domain/GraphGroup.java
@@ -1,0 +1,28 @@
+package be.greenroom.graph.domain;
+
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+
+public enum GraphGroup {
+	WORK_STRUCTURE,
+	LEADERSHIP,
+	PEER_RELATIONS,
+	CAREER_GROWTH,
+	CULTURE_SYSTEM,
+	EMOTIONAL_EXHAUSTION;
+
+	public static GraphGroup from(String value) {
+		if (value == null || value.isBlank()) {
+			throw new CustomException(ErrorCode.GRAPH_INVALID_GROUP);
+		}
+		try {
+			return GraphGroup.valueOf(value.trim().toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new CustomException(ErrorCode.GRAPH_INVALID_GROUP);
+		}
+	}
+
+	public String toApiValue() {
+		return name().toLowerCase();
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/domain/GraphTrend.java
+++ b/greenroom/src/main/java/be/greenroom/graph/domain/GraphTrend.java
@@ -1,0 +1,25 @@
+package be.greenroom.graph.domain;
+
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+
+public enum GraphTrend {
+	INCREASING,
+	STABLE,
+	DECREASING;
+
+	public static GraphTrend from(String value) {
+		if (value == null || value.isBlank()) {
+			throw new CustomException(ErrorCode.GRAPH_INVALID_TREND);
+		}
+		try {
+			return GraphTrend.valueOf(value.trim().toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new CustomException(ErrorCode.GRAPH_INVALID_TREND);
+		}
+	}
+
+	public String toApiValue() {
+		return name().toLowerCase();
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/domain/UserGraphEdge.java
+++ b/greenroom/src/main/java/be/greenroom/graph/domain/UserGraphEdge.java
@@ -1,0 +1,157 @@
+package be.greenroom.graph.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.Check;
+import org.hibernate.annotations.ColumnDefault;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Check(constraints = "NOT (source_label = target_label AND source_grp = target_grp)")
+@Table(
+	name = "user_graph_edges",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_user_edge", columnNames = {
+			"user_id", "source_label", "source_grp", "target_label", "target_grp"
+		})
+	},
+	indexes = {
+		@Index(name = "idx_user_edge_user_id", columnList = "user_id")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGraphEdge {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "source_label", nullable = false, length = 200)
+	private String sourceLabel;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "source_grp", nullable = false, length = 50)
+	private GraphGroup sourceGroup;
+
+	@Column(name = "target_label", nullable = false, length = 200)
+	private String targetLabel;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "target_grp", nullable = false, length = 50)
+	private GraphGroup targetGroup;
+
+	@ColumnDefault("1")
+	@Column(nullable = false)
+	private int weight = 1;
+
+	@ColumnDefault("'related'")
+	@Column(nullable = false, length = 100)
+	private String relationship = "related";
+
+	@Column(name = "first_seen", nullable = false)
+	private LocalDateTime firstSeen;
+
+	@Column(name = "last_seen", nullable = false)
+	private LocalDateTime lastSeen;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Builder
+	private UserGraphEdge(
+		UUID userId,
+		String sourceLabel,
+		GraphGroup sourceGroup,
+		String targetLabel,
+		GraphGroup targetGroup,
+		int weight,
+		String relationship,
+		LocalDateTime firstSeen,
+		LocalDateTime lastSeen
+	) {
+		this.userId = userId;
+		this.sourceLabel = sourceLabel;
+		this.sourceGroup = sourceGroup;
+		this.targetLabel = targetLabel;
+		this.targetGroup = targetGroup;
+		this.weight = weight;
+		this.relationship = relationship;
+		this.firstSeen = firstSeen;
+		this.lastSeen = lastSeen;
+	}
+
+	public static UserGraphEdge create(
+		UUID userId,
+		String sourceLabel,
+		GraphGroup sourceGroup,
+		String targetLabel,
+		GraphGroup targetGroup,
+		int weight,
+		String relationship,
+		LocalDateTime firstSeen,
+		LocalDateTime lastSeen
+	) {
+		return UserGraphEdge.builder()
+			.userId(userId)
+			.sourceLabel(sourceLabel)
+			.sourceGroup(sourceGroup)
+			.targetLabel(targetLabel)
+			.targetGroup(targetGroup)
+			.weight(weight)
+			.relationship(relationship)
+			.firstSeen(firstSeen)
+			.lastSeen(lastSeen)
+			.build();
+	}
+
+	public void updateCumulative(int weight, String relationship, LocalDateTime lastSeen) {
+		this.weight = weight;
+		this.relationship = relationship;
+		this.lastSeen = lastSeen;
+	}
+
+	@PrePersist
+	void prePersist() {
+		LocalDateTime now = LocalDateTime.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		if (firstSeen == null) {
+			firstSeen = now;
+		}
+		if (lastSeen == null) {
+			lastSeen = now;
+		}
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/domain/UserGraphNode.java
+++ b/greenroom/src/main/java/be/greenroom/graph/domain/UserGraphNode.java
@@ -1,0 +1,149 @@
+package be.greenroom.graph.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.ColumnDefault;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "user_graph_nodes",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uq_user_label_grp", columnNames = {"user_id", "label", "grp"})
+	},
+	indexes = {
+		@Index(name = "idx_user_id", columnList = "user_id"),
+		@Index(name = "idx_user_grp", columnList = "user_id, grp")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGraphNode {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(nullable = false, length = 200)
+	private String label;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "grp", nullable = false, length = 50)
+	private GraphGroup group;
+
+	@ColumnDefault("0.5")
+	@Column(nullable = false)
+	private double weight = 0.5d;
+
+	@ColumnDefault("1")
+	@Column(name = "mention_count", nullable = false)
+	private int mentionCount = 1;
+
+	@Enumerated(EnumType.STRING)
+	@ColumnDefault("'STABLE'")
+	@Column(nullable = false, length = 20)
+	private GraphTrend trend = GraphTrend.STABLE;
+
+	@Column(name = "first_seen", nullable = false)
+	private LocalDateTime firstSeen;
+
+	@Column(name = "last_seen", nullable = false)
+	private LocalDateTime lastSeen;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Builder
+	private UserGraphNode(
+		UUID userId,
+		String label,
+		GraphGroup group,
+		double weight,
+		int mentionCount,
+		GraphTrend trend,
+		LocalDateTime firstSeen,
+		LocalDateTime lastSeen
+	) {
+		this.userId = userId;
+		this.label = label;
+		this.group = group;
+		this.weight = weight;
+		this.mentionCount = mentionCount;
+		this.trend = trend;
+		this.firstSeen = firstSeen;
+		this.lastSeen = lastSeen;
+	}
+
+	public static UserGraphNode create(
+		UUID userId,
+		String label,
+		GraphGroup group,
+		double weight,
+		int mentionCount,
+		GraphTrend trend,
+		LocalDateTime firstSeen,
+		LocalDateTime lastSeen
+	) {
+		return UserGraphNode.builder()
+			.userId(userId)
+			.label(label)
+			.group(group)
+			.weight(weight)
+			.mentionCount(mentionCount)
+			.trend(trend)
+			.firstSeen(firstSeen)
+			.lastSeen(lastSeen)
+			.build();
+	}
+
+	public void updateCumulative(double weight, int mentionCount, GraphTrend trend, LocalDateTime lastSeen) {
+		this.weight = weight;
+		this.mentionCount = mentionCount;
+		this.trend = trend;
+		this.lastSeen = lastSeen;
+	}
+
+	@PrePersist
+	void prePersist() {
+		LocalDateTime now = LocalDateTime.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		if (updatedAt == null) {
+			updatedAt = now;
+		}
+		if (firstSeen == null) {
+			firstSeen = now;
+		}
+		if (lastSeen == null) {
+			lastSeen = now;
+		}
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/request/CreateGraphAnalysisRequest.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/request/CreateGraphAnalysisRequest.java
@@ -1,0 +1,16 @@
+package be.greenroom.graph.dto.request;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateGraphAnalysisRequest(
+	@JsonProperty("user_id") @NotNull UUID userId,
+	@JsonProperty("episode_id") String episodeId,
+	@JsonProperty("session_id") String sessionId,
+	@JsonProperty("analysis_type") @NotNull String analysisType,
+	@NotNull Object payload
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphCumulativePayload.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphCumulativePayload.java
@@ -1,0 +1,9 @@
+package be.greenroom.graph.dto.request;
+
+import java.util.List;
+
+public record GraphCumulativePayload(
+	List<GraphNodeUpsertItem> nodes,
+	List<GraphEdgeUpsertItem> links
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphEdgeUpsertItem.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphEdgeUpsertItem.java
@@ -1,0 +1,17 @@
+package be.greenroom.graph.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GraphEdgeUpsertItem(
+	@JsonProperty("source_label") String sourceLabel,
+	@JsonProperty("source_grp") String sourceGrp,
+	@JsonProperty("target_label") String targetLabel,
+	@JsonProperty("target_grp") String targetGrp,
+	Integer weight,
+	String relationship,
+	@JsonProperty("first_seen") LocalDateTime firstSeen,
+	@JsonProperty("last_seen") LocalDateTime lastSeen
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphNodeUpsertItem.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/request/GraphNodeUpsertItem.java
@@ -1,0 +1,16 @@
+package be.greenroom.graph.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GraphNodeUpsertItem(
+	String label,
+	String grp,
+	Double weight,
+	@JsonProperty("mention_count") Integer mentionCount,
+	String trend,
+	@JsonProperty("first_seen") LocalDateTime firstSeen,
+	@JsonProperty("last_seen") LocalDateTime lastSeen
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/request/PutGraphNodesRequest.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/request/PutGraphNodesRequest.java
@@ -1,0 +1,15 @@
+package be.greenroom.graph.dto.request;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record PutGraphNodesRequest(
+	@JsonProperty("user_id") @NotNull UUID userId,
+	@NotNull String type,
+	@Valid @NotNull GraphCumulativePayload data
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphCumulativeDataResponse.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphCumulativeDataResponse.java
@@ -1,0 +1,9 @@
+package be.greenroom.graph.dto.response;
+
+import java.util.List;
+
+public record GraphCumulativeDataResponse(
+	List<GraphNodeResponse> nodes,
+	List<GraphEdgeResponse> links
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphEdgeResponse.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphEdgeResponse.java
@@ -1,0 +1,46 @@
+package be.greenroom.graph.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import be.greenroom.graph.domain.UserGraphEdge;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GraphEdgeResponse(
+	@JsonProperty("source_label") String sourceLabel,
+	@JsonProperty("source_grp") String sourceGrp,
+	@JsonProperty("target_label") String targetLabel,
+	@JsonProperty("target_grp") String targetGrp,
+	Integer weight,
+	String relationship,
+	@JsonProperty("first_seen") LocalDateTime firstSeen,
+	@JsonProperty("last_seen") LocalDateTime lastSeen
+) {
+	public static GraphEdgeResponse forCumulative(UserGraphEdge edge) {
+		return new GraphEdgeResponse(
+			edge.getSourceLabel(),
+			edge.getSourceGroup().toApiValue(),
+			edge.getTargetLabel(),
+			edge.getTargetGroup().toApiValue(),
+			edge.getWeight(),
+			edge.getRelationship(),
+			edge.getFirstSeen(),
+			edge.getLastSeen()
+		);
+	}
+
+	public static GraphEdgeResponse forVisualization(UserGraphEdge edge) {
+		return new GraphEdgeResponse(
+			edge.getSourceLabel(),
+			null,
+			edge.getTargetLabel(),
+			null,
+			edge.getWeight(),
+			null,
+			null,
+			null
+		);
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphNodeResponse.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphNodeResponse.java
@@ -1,0 +1,46 @@
+package be.greenroom.graph.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import be.greenroom.graph.domain.UserGraphNode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GraphNodeResponse(
+	String label,
+	String group,
+	@JsonProperty("grp") String grp,
+	Double weight,
+	@JsonProperty("mention_count") Integer mentionCount,
+	String trend,
+	@JsonProperty("first_seen") LocalDateTime firstSeen,
+	@JsonProperty("last_seen") LocalDateTime lastSeen
+) {
+	public static GraphNodeResponse forCumulative(UserGraphNode node) {
+		return new GraphNodeResponse(
+			node.getLabel(),
+			null,
+			node.getGroup().toApiValue(),
+			node.getWeight(),
+			node.getMentionCount(),
+			node.getTrend().toApiValue(),
+			node.getFirstSeen(),
+			node.getLastSeen()
+		);
+	}
+
+	public static GraphNodeResponse forVisualization(UserGraphNode node) {
+		return new GraphNodeResponse(
+			node.getLabel(),
+			node.getGroup().toApiValue(),
+			null,
+			node.getWeight(),
+			node.getMentionCount(),
+			null,
+			null,
+			null
+		);
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphNodesResponse.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphNodesResponse.java
@@ -1,0 +1,12 @@
+package be.greenroom.graph.dto.response;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GraphNodesResponse(
+	@JsonProperty("user_id") UUID userId,
+	String type,
+	GraphCumulativeDataResponse data
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphUserDataResponse.java
+++ b/greenroom/src/main/java/be/greenroom/graph/dto/response/GraphUserDataResponse.java
@@ -1,0 +1,13 @@
+package be.greenroom.graph.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GraphUserDataResponse(
+	List<GraphNodeResponse> nodes,
+	List<GraphEdgeResponse> links,
+	@JsonProperty("category_distribution") Map<String, Long> categoryDistribution
+) {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/repository/GraphAnalysisRepository.java
+++ b/greenroom/src/main/java/be/greenroom/graph/repository/GraphAnalysisRepository.java
@@ -1,0 +1,8 @@
+package be.greenroom.graph.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import be.greenroom.graph.domain.GraphAnalysis;
+
+public interface GraphAnalysisRepository extends JpaRepository<GraphAnalysis, Long> {
+}

--- a/greenroom/src/main/java/be/greenroom/graph/repository/UserGraphEdgeRepository.java
+++ b/greenroom/src/main/java/be/greenroom/graph/repository/UserGraphEdgeRepository.java
@@ -1,0 +1,22 @@
+package be.greenroom.graph.repository;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import be.greenroom.graph.domain.GraphGroup;
+import be.greenroom.graph.domain.UserGraphEdge;
+
+public interface UserGraphEdgeRepository extends JpaRepository<UserGraphEdge, Long> {
+	List<UserGraphEdge> findByUserIdOrderByLastSeenDesc(UUID userId);
+
+	Optional<UserGraphEdge> findByUserIdAndSourceLabelAndSourceGroupAndTargetLabelAndTargetGroup(
+		UUID userId,
+		String sourceLabel,
+		GraphGroup sourceGroup,
+		String targetLabel,
+		GraphGroup targetGroup
+	);
+}

--- a/greenroom/src/main/java/be/greenroom/graph/repository/UserGraphNodeRepository.java
+++ b/greenroom/src/main/java/be/greenroom/graph/repository/UserGraphNodeRepository.java
@@ -1,0 +1,16 @@
+package be.greenroom.graph.repository;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import be.greenroom.graph.domain.GraphGroup;
+import be.greenroom.graph.domain.UserGraphNode;
+
+public interface UserGraphNodeRepository extends JpaRepository<UserGraphNode, Long> {
+	List<UserGraphNode> findByUserIdOrderByLastSeenDesc(UUID userId);
+
+	Optional<UserGraphNode> findByUserIdAndLabelAndGroup(UUID userId, String label, GraphGroup group);
+}

--- a/greenroom/src/main/java/be/greenroom/graph/repository/dao/OrganizationGraphQueryDao.java
+++ b/greenroom/src/main/java/be/greenroom/graph/repository/dao/OrganizationGraphQueryDao.java
@@ -1,0 +1,103 @@
+package be.greenroom.graph.repository.dao;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import be.greenroom.graph.dto.response.GraphEdgeResponse;
+import be.greenroom.graph.dto.response.GraphNodeResponse;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrganizationGraphQueryDao {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public List<GraphNodeResponse> findOrganizationNodes() {
+		return jdbcTemplate.query(
+			"""
+				SELECT
+				    gn.label,
+				    gn.grp,
+				    AVG(gn.weight) AS weight,
+				    SUM(gn.mention_count) AS mention_count
+				FROM greenroom.user_graph_nodes gn
+				JOIN auth.users u
+				  ON u.id = gn.user_id
+				WHERE u.is_deleted = false
+				  AND u.is_active = true
+				GROUP BY gn.label, gn.grp
+				ORDER BY mention_count DESC, weight DESC, gn.label ASC
+				""",
+			(rs, rowNum) -> new GraphNodeResponse(
+				rs.getString("label"),
+				rs.getString("grp"),
+				null,
+				rs.getDouble("weight"),
+				rs.getInt("mention_count"),
+				null,
+				null,
+				null
+			)
+		);
+	}
+
+	public List<GraphEdgeResponse> findOrganizationLinks() {
+		return jdbcTemplate.query(
+			"""
+				SELECT
+				    ge.source_label,
+				    ge.target_label,
+				    SUM(ge.weight) AS weight
+				FROM greenroom.user_graph_edges ge
+				JOIN auth.users u
+				  ON u.id = ge.user_id
+				WHERE u.is_deleted = false
+				  AND u.is_active = true
+				GROUP BY
+				    ge.source_label,
+				    ge.source_grp,
+				    ge.target_label,
+				    ge.target_grp
+				ORDER BY weight DESC, ge.source_label ASC, ge.target_label ASC
+				""",
+			(rs, rowNum) -> new GraphEdgeResponse(
+				rs.getString("source_label"),
+				null,
+				rs.getString("target_label"),
+				null,
+				rs.getInt("weight"),
+				null,
+				null,
+				null
+			)
+		);
+	}
+
+	public Map<String, Long> findOrganizationCategoryDistribution() {
+		List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+			"""
+				SELECT
+				    gn.grp,
+				    SUM(gn.mention_count) AS mention_count
+				FROM greenroom.user_graph_nodes gn
+				JOIN auth.users u
+				  ON u.id = gn.user_id
+				WHERE u.is_deleted = false
+				  AND u.is_active = true
+				GROUP BY gn.grp
+				ORDER BY mention_count DESC, gn.grp ASC
+				"""
+		);
+
+		Map<String, Long> result = new LinkedHashMap<>();
+		for (Map<String, Object> row : rows) {
+			result.put((String) row.get("grp"), ((Number) row.get("mention_count")).longValue());
+		}
+		return result;
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/service/GraphCommandService.java
+++ b/greenroom/src/main/java/be/greenroom/graph/service/GraphCommandService.java
@@ -1,0 +1,145 @@
+package be.greenroom.graph.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+import be.common.utils.Preconditions;
+import be.greenroom.graph.domain.GraphAnalysis;
+import be.greenroom.graph.domain.GraphGroup;
+import be.greenroom.graph.domain.GraphTrend;
+import be.greenroom.graph.domain.UserGraphEdge;
+import be.greenroom.graph.domain.UserGraphNode;
+import be.greenroom.graph.dto.request.CreateGraphAnalysisRequest;
+import be.greenroom.graph.dto.request.GraphEdgeUpsertItem;
+import be.greenroom.graph.dto.request.GraphNodeUpsertItem;
+import be.greenroom.graph.dto.request.PutGraphNodesRequest;
+import be.greenroom.graph.repository.GraphAnalysisRepository;
+import be.greenroom.graph.repository.UserGraphEdgeRepository;
+import be.greenroom.graph.repository.UserGraphNodeRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GraphCommandService {
+
+	private static final String GRAPH_CUMULATIVE_TYPE = "graph_cumulative";
+
+	private final UserGraphNodeRepository userGraphNodeRepository;
+	private final UserGraphEdgeRepository userGraphEdgeRepository;
+	private final GraphAnalysisRepository graphAnalysisRepository;
+	private final ObjectMapper objectMapper;
+
+	@Transactional
+	public void upsertCumulativeGraph(PutGraphNodesRequest request) {
+		Preconditions.validate(
+			request.data() != null,
+			ErrorCode.GRAPH_PAYLOAD_REQUIRED
+		);
+		Preconditions.validate(
+			GRAPH_CUMULATIVE_TYPE.equals(request.type()),
+			ErrorCode.GRAPH_INVALID_REQUEST_TYPE
+		);
+
+		// 노드 목록을 순회하며 기존 노드는 누적 업데이트, 신규 노드는 새로 저장
+		for (GraphNodeUpsertItem node : safeNodes(request)) {
+			GraphGroup group = GraphGroup.from(node.grp());
+			GraphTrend trend = GraphTrend.from(node.trend());
+			String label = requireText(node.label(), ErrorCode.GRAPH_NODE_LABEL_REQUIRED);
+			double weight = requireDouble(node.weight(), ErrorCode.GRAPH_WEIGHT_REQUIRED);
+			int mentionCount = requireInt(node.mentionCount(), ErrorCode.GRAPH_MENTION_COUNT_REQUIRED);
+			LocalDateTime firstSeen = node.firstSeen() != null ? node.firstSeen() : LocalDateTime.now();
+			LocalDateTime lastSeen = node.lastSeen() != null ? node.lastSeen() : firstSeen;
+			userGraphNodeRepository.findByUserIdAndLabelAndGroup(request.userId(), label, group)
+				.ifPresentOrElse(existing -> {
+					existing.updateCumulative(weight, mentionCount, trend, lastSeen);
+				}, () -> userGraphNodeRepository.save(UserGraphNode.create(
+					request.userId(),
+					label,
+					group,
+					weight,
+					mentionCount,
+					trend,
+					firstSeen,
+					lastSeen
+				)));
+		}
+
+		// 엣지 목록을 순회하며 기존 엣지는 누적 업데이트, 신규 엣지는 새로 저장
+		for (GraphEdgeUpsertItem edge : safeLinks(request)) {
+			GraphGroup sourceGroup = GraphGroup.from(edge.sourceGrp());
+			GraphGroup targetGroup = GraphGroup.from(edge.targetGrp());
+			String sourceLabel = requireText(edge.sourceLabel(), ErrorCode.GRAPH_EDGE_SOURCE_LABEL_REQUIRED);
+			String targetLabel = requireText(edge.targetLabel(), ErrorCode.GRAPH_EDGE_TARGET_LABEL_REQUIRED);
+			String relationship = requireText(edge.relationship(), ErrorCode.GRAPH_EDGE_RELATIONSHIP_REQUIRED);
+			int weight = requireInt(edge.weight(), ErrorCode.GRAPH_WEIGHT_REQUIRED);
+			LocalDateTime firstSeen = edge.firstSeen() != null ? edge.firstSeen() : LocalDateTime.now();
+			LocalDateTime lastSeen = edge.lastSeen() != null ? edge.lastSeen() : firstSeen;
+			userGraphEdgeRepository.findByUserIdAndSourceLabelAndSourceGroupAndTargetLabelAndTargetGroup(
+					request.userId(),
+					sourceLabel,
+					sourceGroup,
+					targetLabel,
+					targetGroup
+				)
+				.ifPresentOrElse(existing -> {
+					existing.updateCumulative(weight, relationship, lastSeen);
+				}, () -> userGraphEdgeRepository.save(UserGraphEdge.create(
+					request.userId(),
+					sourceLabel,
+					sourceGroup,
+					targetLabel,
+					targetGroup,
+					weight,
+					relationship,
+					firstSeen,
+					lastSeen
+				)));
+		}
+	}
+
+	@Transactional
+	public void saveGraphAnalysis(CreateGraphAnalysisRequest request) {
+		Preconditions.validate(request.payload() != null, ErrorCode.GRAPH_PAYLOAD_REQUIRED);
+		try {
+			graphAnalysisRepository.save(GraphAnalysis.create(
+				request.userId(),
+				request.episodeId(),
+				request.sessionId(),
+				requireText(request.analysisType(), ErrorCode.GRAPH_ANALYSIS_TYPE_REQUIRED),
+				objectMapper.writeValueAsString(request.payload())
+			));
+		} catch (JsonProcessingException e) {
+			throw new CustomException(ErrorCode.GRAPH_ANALYSIS_PAYLOAD_SERIALIZATION_FAILED);
+		}
+	}
+
+	private Iterable<GraphNodeUpsertItem> safeNodes(PutGraphNodesRequest request) {
+		return request.data().nodes() == null ? java.util.List.of() : request.data().nodes();
+	}
+
+	private Iterable<GraphEdgeUpsertItem> safeLinks(PutGraphNodesRequest request) {
+		return request.data().links() == null ? java.util.List.of() : request.data().links();
+	}
+
+	private String requireText(String value, ErrorCode errorCode) {
+		Preconditions.validate(value != null && !value.isBlank(), errorCode);
+		return value.trim();
+	}
+
+	private double requireDouble(Double value, ErrorCode errorCode) {
+		Preconditions.validate(value != null, errorCode);
+		return value;
+	}
+
+	private int requireInt(Integer value, ErrorCode errorCode) {
+		Preconditions.validate(value != null, errorCode);
+		return value;
+	}
+}

--- a/greenroom/src/main/java/be/greenroom/graph/service/GraphQueryService.java
+++ b/greenroom/src/main/java/be/greenroom/graph/service/GraphQueryService.java
@@ -1,0 +1,239 @@
+package be.greenroom.graph.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+import be.common.utils.Preconditions;
+import be.greenroom.graph.dto.response.GraphCumulativeDataResponse;
+import be.greenroom.graph.dto.response.GraphEdgeResponse;
+import be.greenroom.graph.dto.response.GraphNodeResponse;
+import be.greenroom.graph.dto.response.GraphNodesResponse;
+import be.greenroom.graph.dto.response.GraphUserDataResponse;
+import be.greenroom.graph.repository.dao.OrganizationGraphQueryDao;
+import be.greenroom.graph.repository.UserGraphEdgeRepository;
+import be.greenroom.graph.repository.UserGraphNodeRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GraphQueryService {
+
+	private static final String GRAPH_CUMULATIVE_TYPE = "graph_cumulative";
+
+	private final UserGraphNodeRepository userGraphNodeRepository;
+	private final UserGraphEdgeRepository userGraphEdgeRepository;
+	private final OrganizationGraphQueryDao organizationGraphQueryDao;
+
+	@Transactional(readOnly = true)
+	public GraphNodesResponse getCumulativeGraph(UUID userId) {
+		List<GraphNodeResponse> nodes = userGraphNodeRepository.findByUserIdOrderByLastSeenDesc(userId)
+			.stream()
+			.map(this::toCumulativeNodeResponse)
+			.toList();
+		List<GraphEdgeResponse> links = userGraphEdgeRepository.findByUserIdOrderByLastSeenDesc(userId)
+			.stream()
+			.map(this::toCumulativeEdgeResponse)
+			.toList();
+
+		return new GraphNodesResponse(userId, GRAPH_CUMULATIVE_TYPE, new GraphCumulativeDataResponse(nodes, links));
+	}
+
+	@Transactional(readOnly = true)
+	public GraphUserDataResponse getGraphVisualizationData(UUID userId) {
+		var nodeEntities = userGraphNodeRepository.findByUserIdOrderByLastSeenDesc(userId);
+		var edgeEntities = userGraphEdgeRepository.findByUserIdOrderByLastSeenDesc(userId);
+		List<GraphNodeResponse> nodes = nodeEntities.stream()
+			.map(this::toVisualizationNodeResponse)
+			.toList();
+		List<GraphEdgeResponse> links = edgeEntities.stream()
+			.map(this::toVisualizationEdgeResponse)
+			.toList();
+
+		Map<String, Long> categoryDistribution = toCategoryDistribution(nodeEntities);
+
+		return validateVisualizationResponse(new GraphUserDataResponse(nodes, links, categoryDistribution));
+	}
+
+	// 조직 전체 활성 사용자 기준 그래프 시각화 데이터를 조회 (하나의 조직만 있다고 가정)
+	@Transactional(readOnly = true)
+	public GraphUserDataResponse getOrganizationGraphVisualizationData() {
+		return validateVisualizationResponse(new GraphUserDataResponse(
+			organizationGraphQueryDao.findOrganizationNodes(),
+			organizationGraphQueryDao.findOrganizationLinks(),
+			organizationGraphQueryDao.findOrganizationCategoryDistribution()
+		));
+	}
+
+	private GraphNodeResponse toCumulativeNodeResponse(be.greenroom.graph.domain.UserGraphNode node) {
+		try {
+			return validateCumulativeNodeResponse(GraphNodeResponse.forCumulative(node));
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH);
+		}
+	}
+
+	private GraphEdgeResponse toCumulativeEdgeResponse(be.greenroom.graph.domain.UserGraphEdge edge) {
+		try {
+			return validateCumulativeEdgeResponse(GraphEdgeResponse.forCumulative(edge));
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH);
+		}
+	}
+
+	private GraphNodeResponse toVisualizationNodeResponse(be.greenroom.graph.domain.UserGraphNode node) {
+		try {
+			return validateVisualizationNodeResponse(GraphNodeResponse.forVisualization(node));
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH);
+		}
+	}
+
+	private GraphEdgeResponse toVisualizationEdgeResponse(be.greenroom.graph.domain.UserGraphEdge edge) {
+		try {
+			return validateVisualizationEdgeResponse(GraphEdgeResponse.forVisualization(edge));
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH);
+		}
+	}
+
+	private GraphNodeResponse validateCumulativeNodeResponse(GraphNodeResponse response) {
+		Preconditions.validate(
+			response.label() != null && !response.label().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.grp() != null && !response.grp().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.weight() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.mentionCount() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.trend() != null && !response.trend().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.firstSeen() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.lastSeen() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		return response;
+	}
+
+	private GraphEdgeResponse validateCumulativeEdgeResponse(GraphEdgeResponse response) {
+		Preconditions.validate(
+			response.sourceLabel() != null && !response.sourceLabel().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.sourceGrp() != null && !response.sourceGrp().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.targetLabel() != null && !response.targetLabel().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.targetGrp() != null && !response.targetGrp().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.weight() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.relationship() != null && !response.relationship().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.firstSeen() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.lastSeen() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		return response;
+	}
+
+	private GraphNodeResponse validateVisualizationNodeResponse(GraphNodeResponse response) {
+		Preconditions.validate(
+			response.label() != null && !response.label().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.group() != null && !response.group().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.weight() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.mentionCount() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		return response;
+	}
+
+	private GraphEdgeResponse validateVisualizationEdgeResponse(GraphEdgeResponse response) {
+		Preconditions.validate(
+			response.sourceLabel() != null && !response.sourceLabel().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.targetLabel() != null && !response.targetLabel().isBlank(),
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.weight() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		return response;
+	}
+
+	private GraphUserDataResponse validateVisualizationResponse(GraphUserDataResponse response) {
+		Preconditions.validate(
+			response.nodes() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.links() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		Preconditions.validate(
+			response.categoryDistribution() != null,
+			ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH
+		);
+		response.nodes().forEach(this::validateVisualizationNodeResponse);
+		response.links().forEach(this::validateVisualizationEdgeResponse);
+		return response;
+	}
+
+	private Map<String, Long> toCategoryDistribution(List<be.greenroom.graph.domain.UserGraphNode> nodeEntities) {
+		try {
+			Map<String, Long> categoryDistribution = new LinkedHashMap<>();
+			nodeEntities.forEach(node ->
+				categoryDistribution.merge(node.getGroup().toApiValue(), (long) node.getMentionCount(), Long::sum)
+			);
+			return categoryDistribution;
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.GRAPH_RESPONSE_SCHEMA_MISMATCH);
+		}
+	}
+}

--- a/greenroom/src/test/java/be/greenroom/graph/controller/GraphControllerTest.java
+++ b/greenroom/src/test/java/be/greenroom/graph/controller/GraphControllerTest.java
@@ -1,0 +1,171 @@
+package be.greenroom.graph.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import be.common.api.ApiAdvice;
+import be.greenroom.graph.dto.response.GraphCumulativeDataResponse;
+import be.greenroom.graph.dto.response.GraphEdgeResponse;
+import be.greenroom.graph.dto.response.GraphNodeResponse;
+import be.greenroom.graph.dto.response.GraphNodesResponse;
+import be.greenroom.graph.dto.response.GraphUserDataResponse;
+import be.greenroom.graph.service.GraphCommandService;
+import be.greenroom.graph.service.GraphQueryService;
+
+class GraphControllerTest {
+
+	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+	private MockMvc mockMvc;
+	private GraphQueryService graphQueryService;
+	private GraphCommandService graphCommandService;
+
+	@BeforeEach
+	void setUp() {
+		graphQueryService = mock(GraphQueryService.class);
+		graphCommandService = mock(GraphCommandService.class);
+		GraphController controller = new GraphController(graphQueryService, graphCommandService);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller)
+			.setControllerAdvice(new ApiAdvice())
+			.build();
+	}
+
+	@Test
+	@DisplayName("누적 그래프 조회 API는 AI 서버용 누적 데이터를 반환한다")
+	void 누적그래프조회_API_성공() throws Exception {
+		when(graphQueryService.getCumulativeGraph(USER_ID)).thenReturn(
+			new GraphNodesResponse(
+				USER_ID,
+				"graph_cumulative",
+				new GraphCumulativeDataResponse(
+					List.of(new GraphNodeResponse("업무과부하", null, "work_structure", 0.81, 3, "increasing", null, null)),
+					List.of(new GraphEdgeResponse("업무과부하", "work_structure", "번아웃", "emotional_exhaustion", 3, "causes", null, null))
+				)
+			)
+		);
+
+		mockMvc.perform(get("/api/v1/graph_nodes").param("user_id", USER_ID.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.user_id").value(USER_ID.toString()))
+			.andExpect(jsonPath("$.data.type").value("graph_cumulative"))
+			.andExpect(jsonPath("$.data.data.nodes[0].grp").value("work_structure"));
+	}
+
+	@Test
+	@DisplayName("누적 그래프 저장 API는 요청을 저장 서비스로 전달한다")
+	void 누적그래프저장_API_성공() throws Exception {
+		String body = """
+			{
+			  "user_id": "11111111-1111-1111-1111-111111111111",
+			  "type": "graph_cumulative",
+			  "data": {
+			    "nodes": [
+			      {
+			        "label": "업무과부하",
+			        "grp": "work_structure",
+			        "weight": 0.81,
+			        "mention_count": 3,
+			        "trend": "increasing"
+			      }
+			    ],
+			    "links": [
+			      {
+			        "source_label": "업무과부하",
+			        "source_grp": "work_structure",
+			        "target_label": "번아웃",
+			        "target_grp": "emotional_exhaustion",
+			        "weight": 3,
+			        "relationship": "causes"
+			      }
+			    ]
+			  }
+			}
+			""";
+
+		mockMvc.perform(put("/api/v1/graph_nodes")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(body))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"));
+
+		verify(graphCommandService).upsertCumulativeGraph(any());
+	}
+
+	@Test
+	@DisplayName("그래프 분석 저장 API는 원본 payload를 저장 서비스로 전달한다")
+	void 그래프분석저장_API_성공() throws Exception {
+		String body = """
+			{
+			  "user_id": "11111111-1111-1111-1111-111111111111",
+			  "episode_id": "ep_001",
+			  "session_id": "sess_001",
+			  "analysis_type": "got_analysis",
+			  "payload": {
+			    "summary": "test"
+			  }
+			}
+			""";
+
+		mockMvc.perform(post("/api/v1/graph_analyses")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(body))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value("ok"));
+
+		verify(graphCommandService).saveGraphAnalysis(any());
+	}
+
+	@Test
+	@DisplayName("사용자 그래프 조회 API는 프론트엔드 시각화 데이터를 반환한다")
+	void 사용자그래프조회_API_성공() throws Exception {
+		when(graphQueryService.getGraphVisualizationData(USER_ID)).thenReturn(
+			new GraphUserDataResponse(
+				List.of(new GraphNodeResponse("의견 무시", "leadership", null, 0.69, 3, null, null, null)),
+				List.of(new GraphEdgeResponse("의견 무시", null, "번아웃", null, 4, null, null, null)),
+				Map.of("leadership", 15L, "emotional_exhaustion", 23L)
+			)
+		);
+
+		mockMvc.perform(get("/api/v1/graph/users/{userId}/data", USER_ID))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.nodes[0].group").value("leadership"))
+			.andExpect(jsonPath("$.data.links[0].source_label").value("의견 무시"))
+			.andExpect(jsonPath("$.data.category_distribution.leadership").value(15));
+	}
+
+	@Test
+	@DisplayName("조직 그래프 조회 API는 조직 시각화 데이터를 반환한다")
+	void 조직그래프조회_API_성공() throws Exception {
+		when(graphQueryService.getOrganizationGraphVisualizationData()).thenReturn(
+			new GraphUserDataResponse(
+				List.of(new GraphNodeResponse("의견 무시", "leadership", null, 0.72, 14, null, null, null)),
+				List.of(new GraphEdgeResponse("의견 무시", null, "번아웃", null, 18, null, null, null)),
+				Map.of("leadership", 52L, "emotional_exhaustion", 77L)
+			)
+		);
+
+		mockMvc.perform(get("/api/v1/graph/organization/data"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.nodes[0].group").value("leadership"))
+			.andExpect(jsonPath("$.data.links[0].weight").value(18))
+			.andExpect(jsonPath("$.data.category_distribution.leadership").value(52));
+	}
+}

--- a/greenroom/src/test/java/be/greenroom/graph/controller/GraphControllerTest.java
+++ b/greenroom/src/test/java/be/greenroom/graph/controller/GraphControllerTest.java
@@ -33,6 +33,8 @@ import be.greenroom.graph.service.GraphQueryService;
 class GraphControllerTest {
 
 	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final String ADMIN_ROLE = "ADMIN";
+	private static final String USER_ROLE = "USER";
 
 	private MockMvc mockMvc;
 	private GraphQueryService graphQueryService;
@@ -144,7 +146,9 @@ class GraphControllerTest {
 			)
 		);
 
-		mockMvc.perform(get("/api/v1/graph/users/{userId}/data", USER_ID))
+		mockMvc.perform(get("/api/v1/graph/users/{userId}/data", USER_ID)
+				.header("X-User-Id", USER_ID.toString())
+				.header("X-User-Role", ADMIN_ROLE))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.nodes[0].group").value("leadership"))
 			.andExpect(jsonPath("$.data.links[0].source_label").value("의견 무시"))
@@ -162,10 +166,22 @@ class GraphControllerTest {
 			)
 		);
 
-		mockMvc.perform(get("/api/v1/graph/organization/data"))
+		mockMvc.perform(get("/api/v1/graph/organization/data")
+				.header("X-User-Id", USER_ID.toString())
+				.header("X-User-Role", ADMIN_ROLE))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.nodes[0].group").value("leadership"))
 			.andExpect(jsonPath("$.data.links[0].weight").value(18))
 			.andExpect(jsonPath("$.data.category_distribution.leadership").value(52));
+	}
+
+	@Test
+	@DisplayName("그래프 API는 ADMIN이 아닌 사용자의 요청을 거부한다")
+	void 그래프_API_권한없음() throws Exception {
+		mockMvc.perform(get("/api/v1/graph/organization/data")
+				.header("X-User-Id", USER_ID.toString())
+				.header("X-User-Role", USER_ROLE))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
 	}
 }

--- a/greenroom/src/test/java/be/greenroom/graph/service/GraphCommandServiceTest.java
+++ b/greenroom/src/test/java/be/greenroom/graph/service/GraphCommandServiceTest.java
@@ -1,0 +1,134 @@
+package be.greenroom.graph.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
+import be.greenroom.graph.domain.GraphAnalysis;
+import be.greenroom.graph.domain.UserGraphEdge;
+import be.greenroom.graph.domain.UserGraphNode;
+import be.greenroom.graph.dto.request.CreateGraphAnalysisRequest;
+import be.greenroom.graph.dto.request.GraphCumulativePayload;
+import be.greenroom.graph.dto.request.GraphEdgeUpsertItem;
+import be.greenroom.graph.dto.request.GraphNodeUpsertItem;
+import be.greenroom.graph.dto.request.PutGraphNodesRequest;
+import be.greenroom.graph.repository.GraphAnalysisRepository;
+import be.greenroom.graph.repository.UserGraphEdgeRepository;
+import be.greenroom.graph.repository.UserGraphNodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GraphCommandServiceTest {
+
+	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+	@Mock
+	private UserGraphNodeRepository userGraphNodeRepository;
+	@Mock
+	private UserGraphEdgeRepository userGraphEdgeRepository;
+	@Mock
+	private GraphAnalysisRepository graphAnalysisRepository;
+	@Spy
+	private ObjectMapper objectMapper;
+
+	@InjectMocks
+	private GraphCommandService graphCommandService;
+
+	@Test
+	@DisplayName("누적 그래프 저장 시 신규 노드와 엣지를 저장한다")
+	void 누적그래프저장_신규저장() {
+		PutGraphNodesRequest request = new PutGraphNodesRequest(
+			USER_ID,
+			"graph_cumulative",
+			new GraphCumulativePayload(
+				List.of(new GraphNodeUpsertItem("업무과부하", "work_structure", 0.81, 3, "increasing", null, null)),
+				List.of(new GraphEdgeUpsertItem("업무과부하", "work_structure", "번아웃", "emotional_exhaustion", 3, "causes", null, null))
+			)
+		);
+		when(userGraphNodeRepository.findByUserIdAndLabelAndGroup(any(), any(), any())).thenReturn(Optional.empty());
+		when(userGraphEdgeRepository.findByUserIdAndSourceLabelAndSourceGroupAndTargetLabelAndTargetGroup(any(), any(), any(), any(), any()))
+			.thenReturn(Optional.empty());
+
+		graphCommandService.upsertCumulativeGraph(request);
+
+		ArgumentCaptor<UserGraphNode> nodeCaptor = ArgumentCaptor.forClass(UserGraphNode.class);
+		ArgumentCaptor<UserGraphEdge> edgeCaptor = ArgumentCaptor.forClass(UserGraphEdge.class);
+		verify(userGraphNodeRepository).save(nodeCaptor.capture());
+		verify(userGraphEdgeRepository).save(edgeCaptor.capture());
+		assertThat(nodeCaptor.getValue().getGroup().toApiValue()).isEqualTo("work_structure");
+		assertThat(edgeCaptor.getValue().getTargetGroup().toApiValue()).isEqualTo("emotional_exhaustion");
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 grp는 검증 오류를 반환한다")
+	void 누적그래프저장_유효하지않은grp_검증오류() {
+		PutGraphNodesRequest request = new PutGraphNodesRequest(
+			USER_ID,
+			"graph_cumulative",
+			new GraphCumulativePayload(
+				List.of(new GraphNodeUpsertItem("업무과부하", "unknown_group", 0.81, 3, "increasing", null, null)),
+				List.of()
+			)
+		);
+
+		CustomException exception = Assertions.assertThrows(CustomException.class,
+			() -> graphCommandService.upsertCumulativeGraph(request));
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GRAPH_INVALID_GROUP);
+	}
+
+	@Test
+	@DisplayName("self-loop 엣지는 데이터베이스 제약에 맡기고 서비스에서 제거하지 않는다")
+	void 누적그래프저장_selfLoop도저장시도() {
+		PutGraphNodesRequest request = new PutGraphNodesRequest(
+			USER_ID,
+			"graph_cumulative",
+			new GraphCumulativePayload(
+				List.of(),
+				List.of(new GraphEdgeUpsertItem("번아웃", "emotional_exhaustion", "번아웃", "emotional_exhaustion", 3, "causes", null, null))
+			)
+		);
+		when(userGraphEdgeRepository.findByUserIdAndSourceLabelAndSourceGroupAndTargetLabelAndTargetGroup(any(), any(), any(), any(), any()))
+			.thenReturn(Optional.empty());
+
+		graphCommandService.upsertCumulativeGraph(request);
+
+		verify(userGraphEdgeRepository).save(any(UserGraphEdge.class));
+	}
+
+	@Test
+	@DisplayName("그래프 분석 저장 시 payload를 JSON 문자열로 저장한다")
+	void 그래프분석저장_payload직렬화() {
+		CreateGraphAnalysisRequest request = new CreateGraphAnalysisRequest(
+			USER_ID,
+			"ep_001",
+			"sess_001",
+			"got_analysis",
+			java.util.Map.of("summary", "test")
+		);
+
+		graphCommandService.saveGraphAnalysis(request);
+
+		ArgumentCaptor<GraphAnalysis> captor = ArgumentCaptor.forClass(GraphAnalysis.class);
+		verify(graphAnalysisRepository).save(captor.capture());
+		assertThat(captor.getValue().getPayload()).contains("summary");
+	}
+}

--- a/greenroom/src/test/java/be/greenroom/graph/service/GraphQueryServiceTest.java
+++ b/greenroom/src/test/java/be/greenroom/graph/service/GraphQueryServiceTest.java
@@ -1,0 +1,97 @@
+package be.greenroom.graph.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import be.greenroom.graph.domain.GraphGroup;
+import be.greenroom.graph.domain.GraphTrend;
+import be.greenroom.graph.domain.UserGraphEdge;
+import be.greenroom.graph.domain.UserGraphNode;
+import be.greenroom.graph.dto.response.GraphEdgeResponse;
+import be.greenroom.graph.dto.response.GraphNodeResponse;
+import be.greenroom.graph.dto.response.GraphNodesResponse;
+import be.greenroom.graph.dto.response.GraphUserDataResponse;
+import be.greenroom.graph.repository.dao.OrganizationGraphQueryDao;
+import be.greenroom.graph.repository.UserGraphEdgeRepository;
+import be.greenroom.graph.repository.UserGraphNodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GraphQueryServiceTest {
+
+	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+	@Mock
+	private UserGraphNodeRepository userGraphNodeRepository;
+	@Mock
+	private UserGraphEdgeRepository userGraphEdgeRepository;
+	@Mock
+	private OrganizationGraphQueryDao organizationGraphQueryDao;
+
+	@InjectMocks
+	private GraphQueryService graphQueryService;
+
+	@Test
+	@DisplayName("AI 서버용 누적 조회는 graph_cumulative 타입으로 반환한다")
+	void 누적조회_응답구성() {
+		when(userGraphNodeRepository.findByUserIdOrderByLastSeenDesc(USER_ID)).thenReturn(List.of(
+			UserGraphNode.create(USER_ID, "업무과부하", GraphGroup.WORK_STRUCTURE, 0.81, 3, GraphTrend.INCREASING, LocalDateTime.now(), LocalDateTime.now())
+		));
+		when(userGraphEdgeRepository.findByUserIdOrderByLastSeenDesc(USER_ID)).thenReturn(List.of());
+
+		GraphNodesResponse result = graphQueryService.getCumulativeGraph(USER_ID);
+
+		assertThat(result.userId()).isEqualTo(USER_ID);
+		assertThat(result.type()).isEqualTo("graph_cumulative");
+		assertThat(result.data().nodes()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("프론트엔드 조회는 category_distribution을 mention_count 기준으로 계산한다")
+	void 시각화조회_카테고리분포계산() {
+		when(userGraphNodeRepository.findByUserIdOrderByLastSeenDesc(USER_ID)).thenReturn(List.of(
+			UserGraphNode.create(USER_ID, "의견 무시", GraphGroup.LEADERSHIP, 0.69, 3, GraphTrend.STABLE, LocalDateTime.now(), LocalDateTime.now()),
+			UserGraphNode.create(USER_ID, "번아웃", GraphGroup.EMOTIONAL_EXHAUSTION, 0.81, 5, GraphTrend.INCREASING, LocalDateTime.now(), LocalDateTime.now())
+		));
+		when(userGraphEdgeRepository.findByUserIdOrderByLastSeenDesc(USER_ID)).thenReturn(List.of(
+			UserGraphEdge.create(USER_ID, "의견 무시", GraphGroup.LEADERSHIP, "번아웃", GraphGroup.EMOTIONAL_EXHAUSTION, 4, "causes", LocalDateTime.now(), LocalDateTime.now())
+		));
+
+		GraphUserDataResponse result = graphQueryService.getGraphVisualizationData(USER_ID);
+
+		assertThat(result.nodes()).hasSize(2);
+		assertThat(result.links()).hasSize(1);
+		assertThat(result.categoryDistribution()).containsEntry("leadership", 3L);
+		assertThat(result.categoryDistribution()).containsEntry("emotional_exhaustion", 5L);
+	}
+
+	@Test
+	@DisplayName("조직 조회는 집계 쿼리 결과를 그대로 시각화 응답으로 반환한다")
+	void 조직조회_응답구성() {
+		when(organizationGraphQueryDao.findOrganizationNodes()).thenReturn(List.of(
+			new GraphNodeResponse("의견 무시", "leadership", null, 0.72, 14, null, null, null)
+		));
+		when(organizationGraphQueryDao.findOrganizationLinks()).thenReturn(List.of(
+			new GraphEdgeResponse("의견 무시", null, "번아웃", null, 18, null, null, null)
+		));
+		when(organizationGraphQueryDao.findOrganizationCategoryDistribution()).thenReturn(
+			java.util.Map.of("leadership", 52L, "emotional_exhaustion", 77L)
+		);
+
+		GraphUserDataResponse result = graphQueryService.getOrganizationGraphVisualizationData();
+
+		assertThat(result.nodes()).hasSize(1);
+		assertThat(result.links()).hasSize(1);
+		assertThat(result.categoryDistribution()).containsEntry("leadership", 52L);
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> 관련된 이슈 번호를 적어주세요. (예: #이슈번호)
closed #75 


## 1️⃣ 작업 내용
## API 흐름 요약

1. AI 서버는 `GET /api/v1/graph_nodes`로 백엔드 DB에서 기존 누적 데이터를 받아와서 읽는다.
2. AI 서버는 EMA 계산 후 `PUT /api/v1/graph_nodes`로 백엔드 서버에 `{ nodes, links }` 형태로 전달한다. 백엔드 서버는 검토 후 DB에 저장한다.
3. `POST /api/v1/graph_analyses`로 원본 분석 결과를 백엔드 서버로 전달한다. 백엔드 서버는 검토 후 DB에 저장한다.
4. 프론트엔드는 `GET /api/v1/graph/users/{userId}/data`, `GET /api/v1/graph/organization/data`
로 `{ nodes, links, category_distribution }`를 백엔드에서 받아온다.


## 2️⃣ 스크린샷
<img width="580" height="386" alt="~ C Test Results" src="https://github.com/user-attachments/assets/73f6324d-4fe8-4bde-9910-a459e9264f05" />

## 3️⃣ 리뷰 요구사항 (선택)
배포 후 AI팀과 호출 테스트 한 뒤, 에러 수정 작업 진행할 예정입니다.

## 📎 참고 자료
현재 API 팀에서는 하나의 유저 단위로만 데이터를 전달합니다.
하지만 피그마 화면에서는 한 조직에 속한 조직원 모두의 데이터를 종합해서 보여주어야 하므로, 백엔드 내부에서 집계가 필요했습니다.

시간 제약상, 한 조직만 사용하는 구조라고 간주하고 `isActive = true`인 사용자 전체를 “조직 구성원”으로 정의했습니다.