### PR TITLE
:recycle: [#85] ai response 필드 수정 

### DIFF
--- a/greenroom/src/main/java/be/greenroom/ai/dto/request/PodcastEpisodeIngestRequest.java
+++ b/greenroom/src/main/java/be/greenroom/ai/dto/request/PodcastEpisodeIngestRequest.java
@@ -1,19 +1,16 @@
 package be.greenroom.ai.dto.request;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PodcastEpisodeIngestRequest(
-	@NotNull UUID userId,
 	@NotBlank String sessionId,
+	@NotBlank String title,
 	String imageUrl,
 	@NotBlank String text
 ) {

--- a/greenroom/src/main/java/be/greenroom/ai/service/PodcastService.java
+++ b/greenroom/src/main/java/be/greenroom/ai/service/PodcastService.java
@@ -3,9 +3,13 @@ package be.greenroom.ai.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import be.common.api.CustomException;
+import be.common.api.ErrorCode;
 import be.greenroom.ai.domain.Podcast;
 import be.greenroom.ai.dto.request.PodcastEpisodeIngestRequest;
 import be.greenroom.ai.repository.PodcastRepository;
+import be.greenroom.ticket.domain.Ticket;
+import be.greenroom.ticket.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -13,12 +17,18 @@ import lombok.RequiredArgsConstructor;
 public class PodcastService {
 
 	private final PodcastRepository podcastRepository;
+	private final TicketRepository ticketRepository;
 
 	@Transactional
 	public void create(PodcastEpisodeIngestRequest request) {
+		Ticket ticket = ticketRepository.findBySessionId(request.sessionId())
+			.orElseThrow(() -> new CustomException(ErrorCode.DOES_NOT_EXIST_TICKET));
+
+		ticket.changeName(request.title());
+
 		podcastRepository.save(
 			Podcast.create(
-				request.userId(),
+				ticket.getUserId(),
 				request.sessionId(),
 				request.imageUrl(),
 				request.text()

--- a/greenroom/src/main/java/be/greenroom/ticket/domain/Ticket.java
+++ b/greenroom/src/main/java/be/greenroom/ticket/domain/Ticket.java
@@ -26,6 +26,9 @@ public class Ticket {
 	@Column
 	private String name;
 
+	@Column
+	private String sessionId;
+
     @Column(nullable = false)
     private String situation;
 
@@ -42,10 +45,11 @@ public class Ticket {
 	@Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    private Ticket(UUID userId, String name, String situation, String thought, String action, String colleagueReaction) {
+    private Ticket(UUID userId, String name, String sessionId, String situation, String thought, String action, String colleagueReaction) {
 		this.id = UUID.randomUUID();
 		this.name = name;
         this.userId = userId;
+		this.sessionId = sessionId;
         this.situation = situation;
         this.thought = thought;
         this.action = action;
@@ -53,7 +57,18 @@ public class Ticket {
     }
 
     public static Ticket create(UUID userId, String name, String situation, String thought, String action, String colleagueReaction) {
-        return new Ticket(userId, name, situation, thought, action, colleagueReaction);
+        return new Ticket(userId, name, null, situation, thought, action, colleagueReaction);
+    }
+
+	public static Ticket createWithSession(
+		UUID userId,
+		String sessionId,
+		String situation,
+		String thought,
+		String action,
+		String colleagueReaction
+	) {
+		return new Ticket(userId, null, sessionId, situation, thought, action, colleagueReaction);
     }
 
 	public void changeName(String name){

--- a/greenroom/src/main/java/be/greenroom/ticket/repository/TicketRepository.java
+++ b/greenroom/src/main/java/be/greenroom/ticket/repository/TicketRepository.java
@@ -2,6 +2,7 @@ package be.greenroom.ticket.repository;
 
 import java.util.List;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ import be.greenroom.ticket.domain.Ticket;
 import be.greenroom.ticket.repository.dao.TicketPreviewDao;
 
 public interface TicketRepository extends JpaRepository<Ticket, UUID> {
+
+	Optional<Ticket> findBySessionId(String sessionId);
 
 	@Query("""
         select new be.greenroom.ticket.repository.dao.TicketPreviewDao(

--- a/greenroom/src/main/java/be/greenroom/ticket/service/AsyncTicketCreateService.java
+++ b/greenroom/src/main/java/be/greenroom/ticket/service/AsyncTicketCreateService.java
@@ -42,11 +42,11 @@ public class AsyncTicketCreateService {
 				null
 			)
 		);
-		Preconditions.validate(response != null && response.name() != null, ErrorCode.INTERNAL_SERVER_ERROR);
+		Preconditions.validate(response != null, ErrorCode.INTERNAL_SERVER_ERROR);
 
-		Ticket ticket = Ticket.create(
+		Ticket ticket = Ticket.createWithSession(
 			userId,
-			response.name(),
+			sessionId,
 			request.situation(),
 			request.thought(),
 			request.action(),

--- a/greenroom/src/test/java/be/greenroom/ai/service/PodcastServiceTest.java
+++ b/greenroom/src/test/java/be/greenroom/ai/service/PodcastServiceTest.java
@@ -1,0 +1,65 @@
+package be.greenroom.ai.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import be.greenroom.ai.domain.Podcast;
+import be.greenroom.ai.dto.request.PodcastEpisodeIngestRequest;
+import be.greenroom.ai.repository.PodcastRepository;
+import be.greenroom.ticket.domain.Ticket;
+import be.greenroom.ticket.repository.TicketRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PodcastServiceTest {
+
+	@Mock
+	private PodcastRepository podcastRepository;
+	@Mock
+	private TicketRepository ticketRepository;
+
+	@InjectMocks
+	private PodcastService podcastService;
+
+	@Test
+	@DisplayName("팟캐스트 ingest 시 sessionId로 티켓을 찾아 제목을 이름으로 저장하고 podcast를 생성한다")
+	void 팟캐스트_인제스트_티켓이름저장_팟캐스트생성() {
+		UUID userId = UUID.randomUUID();
+		Ticket ticket = Ticket.createWithSession(
+			userId,
+			"session-123",
+			"situation",
+			"thought",
+			"action",
+			"reaction"
+		);
+		PodcastEpisodeIngestRequest request = new PodcastEpisodeIngestRequest(
+			"session-123",
+			"episode title",
+			"https://image",
+			"podcast text"
+		);
+
+		when(ticketRepository.findBySessionId("session-123")).thenReturn(Optional.of(ticket));
+
+		podcastService.create(request);
+
+		org.assertj.core.api.Assertions.assertThat(ticket.getName()).isEqualTo("episode title");
+
+		ArgumentCaptor<Podcast> podcastCaptor = ArgumentCaptor.forClass(Podcast.class);
+		verify(podcastRepository).save(podcastCaptor.capture());
+		org.assertj.core.api.Assertions.assertThat(podcastCaptor.getValue().getUserId()).isEqualTo(userId);
+		org.assertj.core.api.Assertions.assertThat(podcastCaptor.getValue().getSessionId()).isEqualTo("session-123");
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> 관련된 이슈 번호를 적어주세요. (예: #이슈번호)
closed #85 


## 1️⃣ 작업 내용

AI 티켓 생성 시 ticket name 대신 sessionId를 저장하도록 변경

Ticket에 sessionId 필드를 추가하고 sessionId 조회 repository 메서드를 추가

podcast episode ingest request에서 userId를 제거하고 title 필드를 추가

ingest 시 sessionId로 Ticket을 조회해 title을 ticket name에 저장하도록 변경

Podcast 저장 시 요청 userId 대신 Ticket.getUserId()를 사용하도록 수정

관련 PodcastService 테스트를 추가



## 2️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해 주세요.


## 3️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해 주세요.